### PR TITLE
Fix: Broken Strapi Docker Setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43297,7 +43297,9 @@
         "@strapi/plugin-cloud": "5.11.2",
         "@strapi/plugin-users-permissions": "5.11.2",
         "@strapi/strapi": "5.11.2",
-        "mysql2": "3.9.8"
+        "mysql2": "3.9.8",
+        "react": "18.3.1",
+        "react-dom": "18.3.1"
       },
       "devDependencies": {
         "@types/node": "^20",

--- a/services/strapi-cms/Dockerfile
+++ b/services/strapi-cms/Dockerfile
@@ -14,6 +14,7 @@ WORKDIR /opt/app
 COPY . .
 RUN chown -R node:node /opt/app
 USER node
+RUN ["yarn"]
 RUN ["yarn", "build"]
 EXPOSE 1337
 CMD ["yarn", "develop"]

--- a/services/strapi-cms/package.json
+++ b/services/strapi-cms/package.json
@@ -18,7 +18,9 @@
     "@strapi/plugin-cloud": "5.11.2",
     "@strapi/plugin-users-permissions": "5.11.2",
     "@strapi/strapi": "5.11.2",
-    "mysql2": "3.9.8"
+    "mysql2": "3.9.8",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
   },
   "devDependencies": {
     "@types/node": "^20",


### PR DESCRIPTION
This pull request includes updates to the `services/strapi-cms` project, focusing on dependency additions and Dockerfile modifications to fix broken setup.

Dependency updates:
* [`services/strapi-cms/package.json`](diffhunk://#diff-0b60090607102d1753364b4f6b302c3d128a09543c141b95454fa7be743bd745L21-R23): Added `react` version 18.3.1 and `react-dom` version 18.3.1 to the dependencies.

Dockerfile modifications:
* [`services/strapi-cms/Dockerfile`](diffhunk://#diff-1f710b4a9884f530360ada3c0922e3b1b4e034bea737b9142182751597bf23ecR17): Added a `RUN ["yarn"]` command to install dependencies before building the project.